### PR TITLE
Prevent leaving Item edit with unsaved changes.

### DIFF
--- a/src/Folio.php
+++ b/src/Folio.php
@@ -162,7 +162,7 @@ class Folio {
   public static function templates() {
 
     $templates = [];
-    $templates[null] = ucwords(strtolower('default template'));
+    $templates["null"] = ucwords(strtolower('default template'));
 
     $template_paths = [];
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -102,6 +102,9 @@ class AdminController extends Controller
 
 				// Template
 				$item->template = Input::get('template');
+				if($item->template == "null") {
+					$item->template = null;
+				}
 
 				// Tags
 		  	$item->tags_str = Input::get('tags_str');


### PR DESCRIPTION
This pull request prevents a user from exiting the Item edit page with unsaved changes, asking to stay or leave.

Basically, the Item gets "dirty" if any of its field have been edited and are different from the original. Every field would reset the "dirty" state to normal if the value is restored except for `textarea` (which probably requires manually checking that the contents of each line are equal to whatever the user has edited.)