### PR TITLE
Add Read More and Excerpt functionality to Item class.

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -184,6 +184,14 @@ return [
 	'middlewares-admin' => ['login', 'web'], // folio admin routes
 
 	/*
+	 * The HTML tags to use on Item's text field to specify where a
+	 * exceprt or teaser end.
+	 * 
+	 */
+	'more-tag' => '<!--more-->',
+	'excerpt-tag' => '<!--excerpt-->',
+
+	/*
 	 * The amount of published items to display in Folio's home page.
 	 * (The rest will be passed as a JavaScript JSON object for "load more".)
 	 */		

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -376,8 +376,6 @@ class Item extends Model implements Feedable
 
 	public static function convertToHtml($text, $markdown_parser = 'default', $veilImages = 'true') {
 
-		//$markdown_parser = $this->stringProperty('markdown-parser', 'default');
-
 		if($markdown_parser == "commonmark") {
 
 			// Obtain a pre-configured Environment with all the CommonMark parsers/renderers ready-to-go

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -449,10 +449,42 @@ class Item extends Model implements Feedable
 	 */
 	public function htmlText($veilImages = true) {
 		$markdown_parser = $this->stringProperty('markdown-parser', 'default');
+		if($this->hasExcerptTag()) {
+			$text = explode(config('folio.excerpt-tag'), $this->text)[1];
+			$html = Item::convertToHtml($text, $markdown_parser, $veilImages);
+			return $html;
+		}		
 		$html = Item::convertToHtml($this->text, $markdown_parser, $veilImages);
 		return $html;
 	}
 	
+	public function hasExcerpt() {
+		return $this->hasMoreTag() || $this->hasExcerptTag();
+	}
+
+	public function hasMoreTag() {
+		return count(explode(config('folio.more-tag'), $this->text)) > 1;
+	}
+
+	public function hasExcerptTag() {
+		return count(explode(config('folio.excerpt-tag'), $this->text)) > 1;
+	}
+	
+	public function htmlTextExcerpt($veilImages = true) {
+		if($this->hasMoreTag()) {
+			$markdown_parser = $this->stringProperty('markdown-parser', 'default');
+			$textExcerpt = explode(config('folio.more-tag'), $this->text)[0];
+			$html = Item::convertToHtml($textExcerpt, $markdown_parser, $veilImages);
+			return $html;
+		} else if($this->hasExcerptTag()) {
+			$markdown_parser = $this->stringProperty('markdown-parser', 'default');
+			$textExcerpt = explode(config('folio.excerpt-tag'), $this->text)[0];
+			$html = Item::convertToHtml($textExcerpt, $markdown_parser, $veilImages);
+			return $html;
+		}
+		return $this->htmlText();
+	}
+
 	/**
 	 * Get the Item's permanent link, constructed with
 	 * the 'permalink-prefix' from Folio's config and


### PR DESCRIPTION
The purpose of this pull request is to add the functionality to specify if a "read more" button should be added because an Item's excerpt is present (either showing a selected initial fragment or a teaser that won't be shown with the actual Item's content).

This pull request does

- [x] Add `more-tag` and `excerpt-tag` options to `config.php` (set by default to `<!--more-->` and `<!--excerpt-->`.
- [x] Add `$item->htmlTextExcerpt()`.
- [x] Add `$item->hasExcerpt()`.
- [x] Add `$item->hasMoreTag()`.
- [x] Add `$item->hasExcerptTag()`.
- [x] `$item->htmlText()` now returns the HTML text without the excerpt if the excerpt tag is present.