### PR TITLE
Localize Items; Draggable properties; Text tag-stripping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.phar
 composer.lock
 .DS_Store
 sy.sh
+Makefile

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Makefile
 .git/
 vendor/
 node_modules/

--- a/_/commands.md
+++ b/_/commands.md
@@ -156,3 +156,36 @@ php artisan folio:toJSON
 - `src/controllers/AdminController.php`
 - `resources/views/admin/item-edit.blade.php`
 - `resources/views/admin/item-list.blade.php`
+
+## Export item properties
+
+```php
+Route::get('export/{id}', function($id) {
+  // Get item
+  $item = Item::find($id);
+  // Encode properties as JSON
+  $json = json_encode($item->properties);
+  // Save file as props.json
+  $filename = $item->id.'.json';
+  if ($item->hasProperty('export-name')) {
+    filename = $item->stringProperty('export-name');    
+  }
+  Storage::put($filename, $json);
+});
+```
+
+## Import item properties
+
+```php
+// Load item properties from JSON
+$contents = File::get(storage_path('app/props.json'));
+// Add each property to item with provided id
+foreach(json_decode($contents) as $prop) {
+    $property = new Property();
+    $property->item_id = $id;
+    $property->label = $prop->label;
+    $property->name = $prop->name;
+    $property->value = $prop->value;
+    $property->save();
+}
+```

--- a/_/migrate-commands.md
+++ b/_/migrate-commands.md
@@ -100,3 +100,59 @@ Artisan::command('folio:retag', function() {
 
 });
 ```
+
+# 2019.06.04 Translations
+
+How to update to translatable models.
+
+## Install
+
+This is done automatically because the dependency is in `composer.json`.
+
+```bash
+# composer require spatie/laravel-translatable
+```
+
+## Database
+
+- rename `title` to `title_plain`
+- rename `text` to `text_plain`
+- create a `title` field that is of JSON type in database table
+- create a `text` field that is of JSON type in database table
+
+## Run migration command
+
+Put this command in your Laravel app, in `routes/console.php`.
+
+```php
+/*
+ * A command to migrate Folio Item's title and text
+ * to JSON to support the HasTranslations trait.
+ */
+Artisan::command('folio:toJSON', function() {
+    
+    $items = Item::withTrashed()->get();
+    app()->setLocale('en');
+    foreach($items as $item) {
+        $this->info("Migrated item $item->id.");
+        $item->title = $item->title_plain;
+        $item->text = $item->text_plain;
+        $item->save();
+    }
+});
+```
+
+Then run the following command on the terminal.
+
+```bash
+php artisan folio:toJSON
+```
+
+## Files edited
+
+- `composer.json`
+- `config/config.php`
+- `src/models/Item.php`
+- `src/controllers/AdminController.php`
+- `resources/views/admin/item-edit.blade.php`
+- `resources/views/admin/item-list.blade.php`

--- a/_/release-notes.md
+++ b/_/release-notes.md
@@ -1,6 +1,10 @@
 
 ## Release Notes
 
+### 5.8.*
+
+- Add item translations (including properties).
+
 ### 5.5.*
 
 - Add package auto-discovery.

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "doctrine/dbal": "^2.9",
         "mpociot/versionable": "~3.1",
         "michelf/php-markdown": "^1.8",
-        "spatie/eloquent-sortable": "^3.6"
+        "spatie/eloquent-sortable": "^3.6",
+        "spatie/laravel-translatable": "^4.1"
     },
     "require-dev": {
         "orchestra/testbench": "~3.0"

--- a/config/config.php
+++ b/config/config.php
@@ -32,6 +32,11 @@ return [
 	],
 
 	/*
+	 * Translations that will show up when editing items. Defaults to ['en'].
+	 */
+	'translations' => ['en'],
+
+	/*
      * The path for Folio to search for custom templates.
 	 * eg. 'template' with search for templates on /resources/views/template.
      */

--- a/config/config.php
+++ b/config/config.php
@@ -49,6 +49,14 @@ return [
      */
 	'domain-pattern' => null,
 	
+	// Pattern of domains accepted by Folio (only to render items)
+	'domain-pattern-items' => 'sketch.nono.ma|sketch.nono.localhost|expensed.me',
+
+	// Main domain to redirect items that are loaded from an unset accepted domain
+	// If null - there's no domain redirection
+	// If existent - redirection happens if no $item->domain() exists
+	'main-domain' => env('FOLIO_DOMAIN', null),
+
 	/*
 	 * Prefix for database tables
      */	

--- a/migrations/2017_01_29_181706_create_items_table.php
+++ b/migrations/2017_01_29_181706_create_items_table.php
@@ -20,9 +20,9 @@ class CreateItemsTable extends Migration
               $table->softDeletes();
               $table->dateTime('published_at')->nullable();
               $table->longText('title')->nullable();
-              // $table->json('text')->nullable(); // only supported by mysql 5.7
-              $table->longText('title')->nullable();
               // $table->json('title')->nullable(); // only supported by mysql 5.7
+              $table->longText('text')->nullable();
+              // $table->json('text')->nullable(); // only supported by mysql 5.7
               $table->string('image')->nullable();
               $table->string('image_src')->nullable();
               $table->string('video')->nullable();

--- a/migrations/2017_01_29_181706_create_items_table.php
+++ b/migrations/2017_01_29_181706_create_items_table.php
@@ -19,8 +19,10 @@ class CreateItemsTable extends Migration
               $table->timestamps();
               $table->softDeletes();
               $table->dateTime('published_at')->nullable();
-              $table->json('title')->nullable();
-              $table->json('text')->nullable();
+              $table->longText('title')->nullable();
+              // $table->json('text')->nullable(); // only supported by mysql 5.7
+              $table->longText('title')->nullable();
+              // $table->json('title')->nullable(); // only supported by mysql 5.7
               $table->string('image')->nullable();
               $table->string('image_src')->nullable();
               $table->string('video')->nullable();

--- a/migrations/2017_01_29_181706_create_items_table.php
+++ b/migrations/2017_01_29_181706_create_items_table.php
@@ -19,8 +19,8 @@ class CreateItemsTable extends Migration
               $table->timestamps();
               $table->softDeletes();
               $table->dateTime('published_at')->nullable();
-              $table->string('title')->nullable();
-              $table->text('text')->nullable();
+              $table->json('title')->nullable();
+              $table->json('text')->nullable();
               $table->string('image')->nullable();
               $table->string('image_src')->nullable();
               $table->string('video')->nullable();

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
         "jquery": "3.1.1",
         "laravel-mix": "1.6.1",
         "validate-js": "2.0.1",
-        "vue": "2.1.10",
+        "vue": "2.6.10",
         "vue-focus": "2.1.0",
         "vue-resource": "1.0.3",
+        "vuedraggable": "^2.21.0",
         "webpack": "3.8.1"
     }
 }

--- a/resources/assets-dev/js/folio.bootstrap.js
+++ b/resources/assets-dev/js/folio.bootstrap.js
@@ -18,6 +18,8 @@ window.Vue = require('vue');
 window.VueResource = require('vue-resource');
 window.Vue.use(window.VueResource);
 window.Focus = require('vue-focus');
+import draggable from "vuedraggable";
+window.draggable = draggable;
 
 /**
  * We'll load the axios HTTP library which allows us to easily issue requests

--- a/resources/views/admin/item-edit.blade.php
+++ b/resources/views/admin/item-edit.blade.php
@@ -288,7 +288,6 @@ methods: {
 	},
 	saveItemChanges() {
 		
-		console.log(this.item);
 		let itemId = this.item.id;
 		let itemData = {
 			title: this.item.title,
@@ -313,8 +312,8 @@ methods: {
 
 			// Force cleanup dirty originalItem
 			if(response.ok) {
-				this.originalItem.title = this.item.title;
-				this.originalItem.text = this.item.text;
+				this.originalItem.title = JSON.parse(JSON.stringify(this.item.title));
+				this.originalItem.text = JSON.parse(JSON.stringify(this.item.text));
 				this.originalItem.video = this.item.video;
 				this.originalItem.published_at = this.item.published_at;
 				this.originalItem.image = this.item.image;

--- a/resources/views/admin/item-list.blade.php
+++ b/resources/views/admin/item-list.blade.php
@@ -210,7 +210,7 @@ admin.sort_tags();
 		<div v-cloak v-for="item in items" class="[ u-visible-vue ] [ admin-list-item ]" v-if="!item.hidden" ref="items">
 			<p v-bind:class="{ 'u-opacity--half': item.deleted_at }">
 				<a v-bind:href="edit_href(item)">
-					@{{ item.title }}
+					@{{ item.title.en || item.title[Object.keys(item.title)[0]] }}
 				</a>
 				<i v-if=" item.deleted_at" @click="toggle_item(item)"
 					 class="[ fa fa-toggle-off fa--social ] [ u-cursor-pointer admin-list-optionLink is-invisible ]"></i>

--- a/resources/views/debug/test.blade.php
+++ b/resources/views/debug/test.blade.php
@@ -3,7 +3,7 @@
 <br>
 
 <h3>grahamcampbell/markdown</h3>
-{!! Markdown::convertToHtml('This is a Markdown *test*—go **bold** letters') !!}
+{!! Item::convertToHtml('This is a Markdown *test*—go **bold** letters') !!}
 
 <h3>jenssegers/date</h3>
 {{ Date::now()->format('M d,   Y') }}

--- a/resources/views/partial/c-item.blade.php
+++ b/resources/views/partial/c-item.blade.php
@@ -68,13 +68,13 @@
 			@if ($item_type == 'DEFAULT_ITEM_TYPE')
 
 				@if ($item->isPublic())
-					{!! $item->htmlText() !!}
+					{!! $item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]) !!}
 				@else
 					@if($twitter_handle = Authenticate::isUserLoggedInTwitter())
 						<?php /*@if($item->visibleFor($twitter_handle) OR Auth::user()->is_admin)*/ ?>
 						@if($item->visibleFor($twitter_handle))
 							{{--Visible for @twitter_handle--}}
-							{!! $item->htmlText() !!}
+							{!! $item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]) !!}
 						@else
 							{{--Not visible for this @twitter_handle--}}
 							<p>Oh, this content doesn't seem to be visible for {{ "@".$twitter_handle }}.</p>
@@ -94,7 +94,7 @@
 
 			@if ($item_type == 'SUMMARY_ITEM_TYPE')
 				<p>
-					{{ Thinker::limitMarkdownText($item->htmlText(), 275, array('figcaption')) }}
+					{{ Thinker::limitMarkdownText($item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]), 275, array('figcaption')) }}
 					{{ Html::link(Folio::path().$item->slug, trans('folio::base.continue-reading')) }}
 				</p>
 			@endif

--- a/resources/views/partial/c-item.blade.php
+++ b/resources/views/partial/c-item.blade.php
@@ -84,7 +84,9 @@
 						<p class="u-text-align--center">
 							Access to see this content.
 							<br><br>
-							<a href="/twitter/login" class="u-a--box-shadow-reset">{{ Form::button('Sign in with Twitter', array('class' => 'button--twitter-hero')) }}</a>
+							<a href="/twitter/login" class="u-a--box-shadow-reset">
+								{{ Form::button('Sign in with Twitter', ['class' => 'button--twitter-hero']) }}
+							</a>
 						</p>
 					@endif
 
@@ -94,7 +96,7 @@
 
 			@if ($item_type == 'SUMMARY_ITEM_TYPE')
 				<p>
-					{{ Thinker::limitMarkdownText($item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]), 275, array('figcaption')) }}
+					{{ Thinker::limitMarkdownText($item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]), 275, ['figcaption']) }}
 					{{ Html::link(Folio::path().$item->slug, trans('folio::base.continue-reading')) }}
 				</p>
 			@endif

--- a/resources/views/profile.blade.php
+++ b/resources/views/profile.blade.php
@@ -1,18 +1,21 @@
-@extends(Config::get("folio.view.layout"))
+@extends(config('folio.view.layout'))
 
 <?php
 
 	// Settings
-	$header_classes = 'c-header--relative';
+	$header_classes = ['c-header--relative'];
+	$header_hidden = true;
 
 	// User Items
 	$items = Item::where('user_id', '=', $user->id)->orderBy('id', 'DESC')->take(5)->get();
 
-	$user_thumbnail = view('folio::partial.c-user-picture')->with(["user" => $user,
-	         													  	 "size" => 75,
-	         													  	 "margin_top" => "-15",
-	         													  	 "margin_bottom" => "15",
-	         													  	 "shouldLink" => false]);
+	$user_thumbnail = view('folio::partial.c-user-picture')->with([
+		"user" => $user,
+		"size" => 75,
+		"margin_top" => "-15",
+		"margin_bottom" => "15",
+		"shouldLink" => false
+	]);
 ?>
 
 
@@ -89,8 +92,6 @@
   </div>
 
 @stop
-
-
 
 @section('footer')
 

--- a/resources/views/template/_base.blade.php
+++ b/resources/views/template/_base.blade.php
@@ -90,7 +90,7 @@ if(isset($collection)) {
           $og_title .= ' (#'.$item->stringProperty('podcast-episode').')';
           $site_title = $og_title.' · '.config('folio.title');
         }
-        $og_description = Thinker::limitMarkdownText($item->htmlText(), 159, ['sup']);
+        $og_description = Thinker::limitMarkdownText($item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]), 159, ['sup']);
         $og_description = $item->stringProperty('meta-description', $og_description);
         $og_type = 'article';
         $og_url = $item->permalink();

--- a/src/Folio.php
+++ b/src/Folio.php
@@ -150,15 +150,9 @@ class Folio {
     }
   }
 
-  // TODO: Place inside Item class
+  // DONE: Place inside Item class
   public static function itemPropertiesWithPrefix($item, $prefix) {
-    $matching_properties = [];
-    foreach($item->properties()->get() as $property) {
-      if (substr($property->name, 0, strlen($prefix)) === $prefix) {
-        array_push($matching_properties, $property);
-      }
-    }
-    return $matching_properties;
+    return $item->itemPropertiesWithPrefix($prefix);
   }
 
   /**

--- a/src/Folio.php
+++ b/src/Folio.php
@@ -79,12 +79,14 @@ class Folio {
 		return Config::get('folio.admin-path-prefix').'/';
 	}
 
-	public static function isAvailableURI() {
-		if(!in_array(Request::path(), config('folio.protected_uris'))) {
+	public static function isReservedURI($uri = null) {
+    if (!$uri) {
+      $uri = Request::path();
+    }
+		if(in_array($uri, config('folio.reserved-uris'))) {
 			return true;
-		} else {
-			return false;
 		}
+    return false;
 	}
 
 	/*

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -63,6 +63,7 @@ class FolioServiceProvider extends ServiceProvider
             $this->commands([
                 \Nonoesp\Folio\Commands\BackupDatabase::class,
                 \Nonoesp\Folio\Commands\MigrateTemplate::class,
+                \Nonoesp\Folio\Commands\TextAndTitleToJSON::class,
             ]);
         }
     }

--- a/src/FolioServiceProvider.php
+++ b/src/FolioServiceProvider.php
@@ -62,6 +62,7 @@ class FolioServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 \Nonoesp\Folio\Commands\BackupDatabase::class,
+                \Nonoesp\Folio\Commands\MigrateTemplate::class,
             ]);
         }
     }

--- a/src/console/MigrateTemplate.php
+++ b/src/console/MigrateTemplate.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Nonoesp\Folio\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+//
+
+class MigrateTemplate extends Command
+{
+    protected $signature = 'folio:migrateTemplate {from?} {to?} {--force} {--preview}';
+
+	protected $description = 'Switch all appearances of a template to another.';
+	
+    public function __construct()
+    {
+		parent::__construct();
+    }
+
+    public function handle()
+    {
+        try {
+            $from = $this->argument('from');    // first argument
+            $to = $this->argument('to');        // second argument
+            $force = $this->option('force');    // --force
+            $preview = $this->option('preview');    // --preview
+            
+            $fromItems = \Item::withTrashed()->where('template', '=', $from)->get();
+            $fromCount = count($fromItems);
+
+            $toItems = \Item::withTrashed()->where('template', '=', $to)->get();
+            $toCount = count($toItems);
+
+            $this->info('- - - - - - - - - - - - ');
+
+            $this->info('[ '.$from.' → '.$to.' ]');
+
+            $this->info('- - - - - - - - - - - - ');
+            
+            $this->info(' [ '.$from.' ]');
+            if(!$fromCount) {
+                $this->info(' No items with origin template.');
+            } else {
+                $this->info(' '.$fromCount.' items with origin template.');
+                $this->info('- - - - - - - - - - - - ');
+            }
+            
+            foreach($fromItems as $item) {
+                $this->info(' · '.$item->title.' ('.$item->id.')');
+            }
+
+            $this->info('- - - - - - - - - - - - ');
+
+
+            $this->info(' [ '.$to.' ]');
+            if(!$toCount) {
+                $this->info(' No items with destination template.');
+            } else {
+                $this->info(' '.$toCount.' items with destination template.');
+                $this->info('- - - - - - - - - - - - ');
+            }
+
+            foreach($toItems as $item) {
+                $this->info(' · '.$item->title.' ('.$item->id.')');
+            }            
+
+            $this->info('- - - - - - - - - - - - ');
+
+            if ($preview) {
+                // Just taking a peek
+                $this->warn(' Just taking a peek.');
+
+            } else if (!$fromCount) {
+                // No origin templates
+                $this->warn(' No items have origin template.');
+                
+            } else if ($fromCount and !$toCount) {
+                // Origin templates and no destination templates
+                $this->info(' Migrating templates.');
+                $this->migrate($fromItems, $to);
+
+            } else if ($toCount and !$force) {
+                // Origin and destination templates, must force
+                $this->warn(' Some items already have destination template. Use --force to migrate.');
+
+            } else if ($fromCount and $toCount and $force) {
+				// Origin and destination templates, forcing
+				$this->info('Forcing migration (even when destination template is in use by items).');
+                $this->migrate($fromItems, $to);
+    
+            }
+            
+            $this->info('- - - - - - - - - - - - ');
+
+        } catch (ProcessFailedException $exception) {
+            return $this->error('The backup process has failed.');
+        }
+    }
+
+    public function migrate($items, $templateTo) {
+        foreach($items as $item) {
+            $item->template = $templateTo;
+            $item->save();
+        }
+    }
+}

--- a/src/console/MigrateTemplate.php
+++ b/src/console/MigrateTemplate.php
@@ -95,7 +95,7 @@ class MigrateTemplate extends Command
             $this->info('- - - - - - - - - - - - ');
 
         } catch (ProcessFailedException $exception) {
-            return $this->error('The backup process has failed.');
+            return $this->error('The migration process has failed.');
         }
     }
 

--- a/src/console/TextAndTitleToJSON.php
+++ b/src/console/TextAndTitleToJSON.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Nonoesp\Folio\Commands;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\Exception\ProcessFailedException;
+
+//
+
+class TextAndTitleToJSON extends Command
+{
+    protected $signature = 'folio:toJSON';
+
+	protected $description = 'Migrate title and text fields to JSON format for localization support.';
+	
+    public function __construct()
+    {
+		parent::__construct();
+    }
+
+    public function handle()
+    {
+        try {
+            
+            $items = \Item::withTrashed()->get();
+            app()->setLocale('en');
+            foreach($items as $item) {
+                $this->info("Migrated item $item->id.");
+                $item->title = $item->title_plain;
+                $item->text = $item->text_plain;
+                $item->save();
+            }
+            $this->info('Migration completed.');
+
+        } catch (ProcessFailedException $exception) {
+            return $this->error('The migration process has failed.');
+        }
+    }
+}

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -297,7 +297,16 @@ class AdminController extends Controller
 
 		return response()->json([
 			'success' => true
-	]);
+		]);
+	}
+
+	function postPropertySort() {
+		$ids = Input::get('ids');
+		Property::setNewOrder($ids);
+
+		return response()->json([
+			'success' => true
+		]);
 	}
 
 	// Items API

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -180,9 +180,23 @@ class AdminController extends Controller
 
 	public function postItemCreate() {
 
+		// Initial values default to English
+		// or first value of folio.translations config array (if valid)
+		$default_locale = 'en';
+		$translations = config('folio.translations');
+		if($translations && in_array($translations[0], \ResourceBundle::getLocales(''))) {
+			$default_locale = $translations[0];
+		}
+		app()->setLocale($default_locale);
+
 		$item = new Item();
 		$item->title = Input::get('title');
-		if($item->title == "") $item->title = "Untitled";
+		if($item->title == "") {
+			$item->title = "Untitled";
+		}
+		if($item->text == "") {
+			$item->text = "";
+		}
 		
 		$item->is_blog = false;
 

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -178,8 +178,7 @@ class AdminController extends Controller
 		return view('folio::admin.item-add');
 	}
 
-	public function postItemCreate() {
-
+	public function setLocateToFirstTranslation() {
 		// Initial values default to English
 		// or first value of folio.translations config array (if valid)
 		$default_locale = 'en';
@@ -188,6 +187,11 @@ class AdminController extends Controller
 			$default_locale = $translations[0];
 		}
 		app()->setLocale($default_locale);
+	}
+
+	public function postItemCreate() {
+
+		$this->setLocateToFirstTranslation();
 
 		$item = new Item();
 		$item->title = Input::get('title');
@@ -344,6 +348,8 @@ class AdminController extends Controller
 	 */
 	
 	public function postItemUpdateAjax(Request $request, $id) {
+
+		$this->setLocateToFirstTranslation();
 
 		$item = Item::withTrashed()->find($id);
 

--- a/src/controllers/FeedController.php
+++ b/src/controllers/FeedController.php
@@ -28,6 +28,9 @@ class FeedController extends Controller
 		if ($item) {
 			$cacheDuration = $item->intProperty('feed-cache-duration', $cacheDuration);
 			$cacheKey = $item->stringProperty('feed-key', $cacheKey);
+			if ($locale = $item->stringProperty('locale')) {
+				app()->setLocale($locale);
+			}
 		}
 		// Cache the feed for X minutes (second parameter is optional)
 		$feed->setCache($cacheDuration, $cacheKey);

--- a/src/controllers/FeedController.php
+++ b/src/controllers/FeedController.php
@@ -141,20 +141,28 @@ class FeedController extends Controller
 					// $image = '<p><img src="'.$item_image.'" alt="'.$item->title.'"></p>';
 				}
 
+				// Item->htmlText()
+				$itemHTMLText = $item->htmlText([
+					'veilImages' => false,
+					'parseExternalLinks' => $request->root(),
+					'stripTags' => ['norss', 'nofeed']
+				]);
+
 				// Text
-				$html = str_replace([
-					'<img',
-					'src="/',
-					'href="/',
-					'<hr />',
-				], [
-					'<img width="100%"',
-					'src="'.$request->root().'/',
-					'href="'.$request->root().'/',
-					'<br />',
-				],
-				$image.
-				$item->htmlText(false, $request->root()));
+				$html = str_replace(
+					[
+						'<img',
+						'src="/',
+						'href="/',
+						'<hr />',
+					], [
+						'<img width="100%"',
+						'src="'.$request->root().'/',
+						'href="'.$request->root().'/',
+						'<br />',
+					],
+					$image.$itemHTMLText
+				);
 
 				$html = str_replace(
 					["<p><img", "/></p>"],
@@ -167,7 +175,7 @@ class FeedController extends Controller
 					'author' => $default_author,
 					'url' => $URL,
 					'pubdate' => $item->published_at,
-					'description' => \Thinker::limitMarkdownText($item->htmlText(), 159, ['sup']),
+					'description' => \Thinker::limitMarkdownText($itemHTMLText, 159, ['sup']),
 					'content' => $html,
 				];
 

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -104,7 +104,11 @@ class Item extends Model implements Feedable
 	}
 
 	public function domain() {
-		return $this->stringProperty('domain', config('folio.main-domain'));
+		$domain = $this->stringProperty('domain', config('folio.main-domain'));
+		if ($domain == null) {
+			return \Request::getHost();
+		}
+		return $domain;
 	}
 
 	// The public path of the item

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -11,6 +11,12 @@ class Item extends Model implements Feedable
 	use \Mpociot\Versionable\VersionableTrait;
 	use SoftDeletes;
 	use \Conner\Tagging\Taggable;
+	use \Spatie\Translatable\HasTranslations;
+
+	/**
+	 * @var array
+	 */
+	public $translatable = ['title', 'text'];
 
 	/**
 	 * @var string

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -103,13 +103,21 @@ class Item extends Model implements Feedable
 		//}
 	}
 
+	public function domain() {
+		return $this->stringProperty('domain', config('folio.main-domain'));
+	}
+
 	// The public path of the item
 	// (Returns 404 if the post is hidden or scheduled for the future)
 	public function path() {
+		$path = Folio::path().$this->slug;
 		if($this->slug[0] == "/") {
-			return substr($this->slug, 1, strlen($this->slug)-1);
+			$path = substr($this->slug, 1, strlen($this->slug)-1);
 		}
-		return Folio::path().$this->slug;
+		if ($this->domain() != \Request::getHost()) {
+			$path = '//'.$this->domain().'/'.$path;
+		}		
+		return $path;
 	}
 
 	// An encoded path that provides access to hidden items

--- a/src/models/Property.php
+++ b/src/models/Property.php
@@ -21,4 +21,9 @@ class Property extends Model implements Sortable
 	{
 		return $this->hasOne('Item');
 	}
+
+	// spatie/sortable
+	public function buildSortQuery() {
+		return static::query()->where('item_id', $this->item_id);
+	}	
 }


### PR DESCRIPTION
This pull request allows to translate Folio items to different languages.

## Item text translations

- Added `translations` config option that accepts and array of locales (e.g., `['en', 'es']`).
- Converted `title` and `text` to `JSON` format.
- Display per-language `title` and `text` fields in item edit page.
- Added migration instructions (and `folio:toJSON` command).
- Installed `spatie/laravel-translatable`.
- Hide item edit fields until Vue component is created.

## Item properties translations

- A custom properties (say, `location`) can automatically get translations (say, `location--es`) into other languages. (Folio checks whether the same `name` of a custom property exists with `--{VALID_LOCALE}` appended to its name.)

## Item properties draggable

- Sortable items by drag-and-dropping.

## Item HTML text (with tag-stripping)

- Change `htmlText` arguments to array of options.
- Allow `stripTags` (array) argument to strip out certain HTML tags (e.g., `<rss></rss>` is hidden in posts but shown in RSS feeds.)