### PR TITLE
Fixes and improvements to Item model

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "nonoesp/authenticate": "^5.7",
         "nonoesp/thinker": "^1.1",
         "jenssegers/date": "^3.5",
-        "laravelium/feed": "dev-master",
+        "laravelium/feed": "3.1.*",
         "graham-campbell/markdown": "10.3.1",
         "webuni/commonmark-attributes-extension": "dev-master",
         "laravelcollective/html": "5.8.*",

--- a/resources/views/admin/item-edit.blade.php
+++ b/resources/views/admin/item-edit.blade.php
@@ -412,7 +412,7 @@ methods: {
 		  '<i class="fa fa-times"></i>' => $item->destroyPath(),
 		  '<i class="fa fa-history"></i>' => $item->versionsPath(),
 		  '<i class="fa fa-link"></i>' => [
-			  $item->encodedPath(),
+			  '//'.$item->encodedPath(true),
 			  'js--encoded-path',
 			  'data-clipboard-text="'.$item->encodedPath(true).'"'],
 		  '<i class="fa fa-eye"></i>' => [

--- a/src/controllers/FeedController.php
+++ b/src/controllers/FeedController.php
@@ -98,9 +98,10 @@ class FeedController extends Controller
 			$feed->setCustomView($feedCustomView);
 
 			foreach ($items as $item) {
-				// Link
-				$URL = URL::to($request->root().'/'.$item->path());
+				// Link for this RSS item
+				$URL = $item->URL();
 				$itemURL = $URL;
+				// Use external link if provided
 				if($item->link) {
 					$URL = $item->link;
 				}

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -113,22 +113,34 @@ class Item extends Model implements Feedable
 
 	// The public path of the item
 	// (Returns 404 if the post is hidden or scheduled for the future)
-	public function path() {
+	public function path($absolute = false) {
 		$path = Folio::path().$this->slug;
 		if($this->slug[0] == "/") {
 			$path = substr($this->slug, 1, strlen($this->slug)-1);
 		}
-		if ($this->domain() != \Request::getHost()) {
+		if (
+			$absolute or
+			$this->domain() != \Request::getHost()
+			) {
 			$path = '//'.$this->domain().'/'.$path;
 		}		
 		return $path;
+	}
+
+	public function URL() {
+		$protocol = 'http:';
+		if (\Request::secure())
+		{
+			$protocol = 'https:';
+		}
+		return $protocol.$this->path(true);
 	}
 
 	// An encoded path that provides access to hidden items
 	public function encodedPath($absolute = false) {
 		$path = '/e/'.\Hashids::encode($this->id);
 		if($absolute) {
-			return \Request::root().$path;
+			return $this->domain().$path;
 		}
 		return $path;
 	}

--- a/src/models/Item.php
+++ b/src/models/Item.php
@@ -127,6 +127,7 @@ class Item extends Model implements Feedable
 		return $path;
 	}
 
+	// The public URL of the item
 	public function URL() {
 		$protocol = 'http:';
 		if (\Request::secure())


### PR DESCRIPTION
- Fix `Item::path()`
- Add `Item::URL()`
- Use `Item::URL()` instead of `Item::path()` in FeedController
- Set `laravelium/feed` to `3.1.*` for compatibility with Laravel `5.8`.