### PR TITLE
Refactor authentication into Folio using Laravel's traits and controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,45 +23,20 @@ Most packages should be auto-discovered by Laravel.
 
 ### Middleware
 
-Publish the required middleware.
-
-```bash
-// TODO - Remove!
-// php artisan vendor:publish --provider="Nonoesp\Folio\FolioServiceProvider" --tag=middleware
-// php artisan vendor:publish --provider="Nonoesp\Authenticate\AuthenticateServiceProvider" --tag=middleware
-```
-
-Then add the following to `app/Http/Kernel.php`:
+Add the following middleware to `app/Http/Kernel.php`:
 
 ```php
-protected $middleware = [
-        /// nonoesp/folio
-        \Nonoesp\Folio\Middleware\SetLocales::class,
-        /// nonoesp/authenticate
-        \Illuminate\Session\Middleware\StartSession::class,
-        \Illuminate\View\Middleware\ShareErrorsFromSession::class,			
-        \Nonoesp\Authenticate\Middleware\RememberLogin::class,        
-        /// ...
-];
-
-protected $routeMiddleware = [
-        /// nonoesp/authenticate
-        'login' => \Nonoesp\Authenticate\Middleware\RequireLogin::class,
-        /// ...
-];
+    protected $middlewareGroups = [
+        'web' => [
+            /// nonoesp/folio
+            \Nonoesp\Folio\Middleware\SetLocales::class,
+        ],
+    ];
 ```
-
-<!-- ### Sign in with Twitter
-
-You need to publish the config file of `thujon/twitter` and add your Twitter credentials to `config/ttwitter.php`. (You can create a Twitter app at <https://apps.twitter.com/>.)
-
-```bash
-php artisan vendor:publish --provider="Thujohn\Twitter\TwitterServiceProvider"
-``` -->
 
 ### Migrations
 
-- Remove Laravel's default migration files from `database/migrations` as they can collide with Folio's migrations.
+- Remove Laravel's default migration files from `database/migrations` as they can collide with Folio's migrations. (`TODO` - Check if this is necessary or Folio's `users` table works.)
 - Setup your database connection in the `.env` file.
 - Publish `rtconner/tagging` migrations:
 
@@ -125,16 +100,13 @@ if (mix.inProduction()) {
 mix.copy('node_modules/folio-scss/vendor/icons-links-gwern', 'public/img/icons');
 
 // BrowserSync when watching (i.e. npm run watch)
-mix.browserSync({
-   proxy: 'localhost:8000',
-   files: []
-});
+// mix.browserSync('localhost:8000');
 ```
 
 - Install dependencies with `npm`.
 
 ```bash
-npm install nonoesp/folio-scss bourbon@4.3.4 font-awesome vue vue-resource vue-focus lodash jquery validate-js vuedraggable
+npm install nonoesp/folio-scss bourbon@4.3.4 font-awesome vue vue-resource vue-focus lodash jquery jquery-lazy validate-js vuedraggable
 npm install
 ```
 
@@ -157,8 +129,9 @@ php artisan vendor:publish --provider="Nonoesp\Folio\FolioServiceProvider" --tag
 
 ## File Uploader
 
-- TODO - Create `storage/public/uploads` folder.
-- TODO - Symlink uploads folder to `public/img/u`.
+- Create `storage/public/uploads` folder.
+- TODO: Give permissions to `uploads` folder.
+- Symlink uploads folder to `public/img/u`.
 
 ```
 ln -s global/path/to/storage/app/public/uploads global/path/to/public/img/u

--- a/_/FolioController-experimental-caching.php
+++ b/_/FolioController-experimental-caching.php
@@ -3,11 +3,11 @@
 namespace Nonoesp\Folio\Controllers;
 
 use Illuminate\Http\Request;
-use Item, User; // Must be defined in your aliases
+use Nonoesp\Models\Item;
+use User; // Must be defined in your aliases
 use Nonoesp\Folio\Folio;
 use View;
 use Config;
-use Authenticate; // Must be installed (nonoesp/authenticate) and defined in your aliases
 use App;
 use Markdown;
 use Auth;
@@ -31,7 +31,8 @@ class FolioController extends Controller
 		// }
 
 		// Get user's Twitter handle (or visitor)
-		$twitter_handle = Authenticate::isUserLoggedInTwitter();
+		//$twitter_handle = Authenticate::isUserLoggedInTwitter();
+		$twitter_handle = Auth::check() ? Auth::user()->twitter : null;
 
 		// Config variables
 		$published_show = Config::get("folio.published-show");
@@ -125,7 +126,8 @@ class FolioController extends Controller
 	public function showItemTag($tag) {
 
 		// Get user's Twitter handle (or visitor)
-		$twitter_handle = Authenticate::isUserLoggedInTwitter();
+		// $twitter_handle = Authenticate::isUserLoggedInTwitter();
+		$twitter_handle = Auth::check() ? Auth::user()->twitter : null;
 
 		// Config variables
 		$published_show = Config::get("folio.published-show");

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
         "rap2hpoutre/laravel-log-viewer": "^1.3",
         "spatie/laravel-feed": "~2.4",
         "mpociot/versionable": "dev-master",
-        "nonoesp/authenticate": "^6.0",
+        "nonoesp/thinker": "^6.0",
         "mtownsend/read-time": "^1.1",
         "symfony/intl": "^5.1@dev",
         "nasyrov/laravel-imgix": "dev-master",

--- a/config/config.php
+++ b/config/config.php
@@ -204,7 +204,7 @@ return [
 	'protected_uris' => ['example', 'profile', 'about', 'magic'], // are not overriden by folio
 
 	'middlewares' => ['web'], // folio routes
-	'middlewares-admin' => ['login', 'web'], // folio admin routes
+	'middlewares-admin' => ['web', 'auth'], // folio admin routes
 
 	/*
 	 * The HTML tags to use on Item's text field to specify where a

--- a/resources/lang/en/base.php
+++ b/resources/lang/en/base.php
@@ -30,4 +30,7 @@ return [
 	'this-page-is-hidden' => 'This page is hidden.',
 	'preview-of-unpublished-page' => 'This is a preview of an unpublished page.',
 
+	// errors
+	'invalid-credentials' => 'Invalid email or password',
+
 ];

--- a/resources/lang/es/base.php
+++ b/resources/lang/es/base.php
@@ -31,4 +31,6 @@ return [
 	'this-page-is-hidden' => 'Esta página está oculta.',
 	'preview-of-unpublished-page' => 'Previsualización de una página no publicada.',
 
+	// errors
+	'invalid-credentials' => 'Email o contraseña no válidos',
 ];

--- a/resources/views/admin/c-menu.blade.php
+++ b/resources/views/admin/c-menu.blade.php
@@ -1,31 +1,36 @@
 <?php
 	$admin_path = Folio::adminPath();
-	$exit = config('authenticate.exit');
 ?>
 
 <div class="admin-menu u-case-upper u-text-align--center">
 
 	<div class="[ m-fa  m-fa--black-static ]">
 
-    	<a href="/{{ $admin_path }}items">
+    	<a href="/{{ Folio::adminPath('items') }}">
       		<i class="[ fa fa-align-justify fa--social ]"></i>
     	</a>
 
-      <a href="/{{ $admin_path }}item/add">
+      <a href="/{{ Folio::adminPath('item/add') }}">
           <i class="[ fa fa-file-o fa--social ]"></i>
       </a>
 
-      <a href="/{{ $admin_path }}upload">
+      <a href="/{{ Folio::adminPath('upload') }}">
           <i class="[ fa fa-file-image-o fa--social ]"></i>
       </a>	  
 
-      <a href="/{{ $admin_path }}subscribers">
+      <a href="/{{ Folio::adminPath('subscribers') }}">
           <i class="[ fa fa-envelope-o fa--social ]"></i>
       </a>
 
-    	<a href="/{{ $exit }}">
+      <a class="dropdown-item" href="{{ route('logout') }}"
+                               onclick="event.preventDefault();
+                                        document.getElementById('logout-form').submit();">
       		<i class="[ fa fa-close fa--social ]"></i>
     	</a>
+
+      <form id="logout-form" action="{{ route('logout') }}" method="POST" style="display: none;">
+        @csrf
+      </form>      
 
   </div>
 

--- a/resources/views/login/layout.blade.php
+++ b/resources/views/login/layout.blade.php
@@ -1,0 +1,50 @@
+<?php
+	$folio_typekit = config('folio.typekit');
+	$folio_css = config('folio.css');
+	if($folio_typekit == '') $folio_typekit = null;
+	if($folio_css == '') $folio_css = null;
+?>
+
+<!DOCTYPE html>
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="initial-scale=1, maximum-scale=1, minimal-ui"/>
+	<title>{{ $site_title ?? 'Admin' }}</title>
+
+	<!--Icon-->
+	<link rel="shortcut icon" href="/img/favicon.png" type="image/png" />
+	<link rel="apple-touch-icon-precomposed" href="img/apple-touch-icon.png" />
+	<link rel="apple-touch-icon" href="img/apple-touch-icon.png" />
+	<link rel="apple-touch-icon" sizes="72x72" href="apple-touch-icon-ipad.png" />
+	<link rel="apple-touch-icon" sizes="114x114" href="apple-touch-icon-@2x.png" />
+	<meta name="apple-mobile-web-app-title" content="{{ config('folio.title') }}" />
+
+	<!--Stylesheets-->
+	<link rel="stylesheet" type="text/css" href="{{ $folio_css ?? '/nonoesp/folio/css/folio.css?default' }}">
+
+	<!-- CSRF Token -->
+	<meta name="csrf-token" content="{{ csrf_token() }}">
+
+	@if($folio_typekit)
+	<!--TypeKit-->
+	<script type="text/javascript" src="//use.typekit.net/{{ $folio_typekit }}.js"></script>
+	<script type="text/javascript">try{Typekit.load();}catch(e){}</script>
+	@endif
+
+</head>
+
+<body>
+
+<div class="[ o-band ] [ u-pad-t-5x ] ">
+	<div class="[ o-wrap  o-wrap--size-400 ]">
+
+	<h3 class="[ c-admin__title ] [ u-border-bottom ]">{{ $headline ?? 'Admin' }}</h3>
+
+	@yield('content')
+
+	</div>
+</div>
+
+</body>
+</html>

--- a/resources/views/login/login.blade.php
+++ b/resources/views/login/login.blade.php
@@ -1,0 +1,25 @@
+@extends('folio::login.layout')
+
+@php
+	$shouldHideMenu = true;
+	$site_title = 'Log In · '.config('folio.title');
+	$headline = session('login.headline') ? session('login.headline') : 'Welcome back, friend.';
+@endphp
+
+@section('content')
+
+    @if(session('error'))
+        <p style="color: #e36129">{{ trans('folio::base.'.session('error')) }}</p>
+    @endif
+
+    <form action="{{ route('login') }}" method="post" accept-charset="UTF-8">
+
+        @csrf
+        <input name="email" type="email" value="{{ session('email') }}" placeholder="Email" {{ session('email') ?: 'autofocus' }}/>
+        <input name="password" type="password" placeholder="Password" {{ session('email') ? 'autofocus' : null }}/>
+        <label><input type="checkbox" name="remember" id="remember" checked> Remember Me</label>
+        <button type="submit">Sign in</button>
+
+    </form>
+
+@endsection

--- a/resources/views/partial/c-item.blade.php
+++ b/resources/views/partial/c-item.blade.php
@@ -62,7 +62,7 @@
 				@if ($item->isPublic())
 					{!! $item->htmlText(['stripTags' => ['rss', 'podcast', 'feed']]) !!}
 				@else
-					@if($twitter_handle = Authenticate::isUserLoggedInTwitter())
+					@if($twitter_handle = Auth::check() ? Auth::user()->twitter : null)
 						<?php /*@if($item->visibleFor($twitter_handle) OR Auth::user()->is_admin)*/ ?>
 						@if($item->visibleFor($twitter_handle))
 							{{--Visible for @twitter_handle--}}

--- a/src/controllers/AdminController.php
+++ b/src/controllers/AdminController.php
@@ -7,7 +7,6 @@ use Item, User, Thinker, Recipient, Property, Subscriber;
 use Nonoesp\Folio\Folio;
 use View;
 use Config;
-use Authenticate; // nonoesp/authenticate
 use Input;
 use Redirect;
 use Date;

--- a/src/controllers/FeedController.php
+++ b/src/controllers/FeedController.php
@@ -7,7 +7,6 @@ use Item, User;
 use Nonoesp\Folio\Folio;
 use View;
 use Config;
-use Authenticate; // nonoesp/authenticate
 use App;
 use Markdown;
 use Auth;

--- a/src/controllers/FolioController.php
+++ b/src/controllers/FolioController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 
 use Nonoesp\Folio\Folio;
 use Item, User;
-use Authenticate; // nonoesp/authenticate
+; // nonoesp/authenticate
 use Auth;
 
 class FolioController extends Controller
@@ -19,7 +19,8 @@ class FolioController extends Controller
 	public function showHome($domain) {
 
 		// Get user's Twitter handle (or visitor)
-		$twitter_handle = Authenticate::isUserLoggedInTwitter();
+		// $twitter_handle = Authenticate::isUserLoggedInTwitter();
+		$twitter_handle = Auth::check() ? Auth::user()->twitter : null;
 
 		// Config variables
 		$published_show = config("folio.published-show");
@@ -99,7 +100,8 @@ class FolioController extends Controller
 	public static function showItemTag($domain, $tag) {
 
 		// Get user's Twitter handle (or visitor)
-		$twitter_handle = Authenticate::isUserLoggedInTwitter();
+		// $twitter_handle = Authenticate::isUserLoggedInTwitter();
+		$twitter_handle = Auth::check() ? Auth::user()->twitter : null;
 
 		// Config variables
 		$published_show = config("folio.published-show");

--- a/src/controllers/LoginController.php
+++ b/src/controllers/LoginController.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Nonoesp\Folio\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Foundation\Auth\AuthenticatesUsers;
+use Illuminate\Http\Request;
+
+class LoginController extends Controller
+{
+    /*
+    |--------------------------------------------------------------------------
+    | Login Controller
+    |--------------------------------------------------------------------------
+    |
+    | This controller handles authenticating users for the application and
+    | redirecting them to your home screen. The controller uses a trait
+    | to conveniently provide its functionality to your applications.
+    |
+    */
+
+    use AuthenticatesUsers;
+
+    /**
+     * Where to redirect users after login.
+     *
+     * @var string
+     */
+    protected $redirectTo = '/admin';
+
+    protected function loggedOut(Request $request)
+    {
+        // Default is '/'
+        return redirect(route('login')); // Nono+
+    }
+
+    // protected function authenticated(Request $request) {
+    //     session(['email' => \Auth::user()->email]); // Nono+
+    // }
+
+    public function logout(Request $request)
+    {
+        $email = \Auth::user()->email; // Nono+
+        
+        $this->guard()->logout();
+
+        $request->session()->invalidate();
+
+        $request->session()->regenerateToken();
+
+        session(['email' => $email]); // Nono+
+
+        return $this->loggedOut($request) ?: redirect('/');
+    }
+
+    protected function sendFailedLoginResponse(Request $request)
+    {
+        // throw \Illuminate\Validation\ValidationException::withMessages([
+        //     $this->username() => [trans('auth.failed')],
+        // ]);
+        return redirect()->back()->with('error', 'invalid-credentials'); // Nono+
+    }
+
+    /**
+     * Create a new controller instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        $this->middleware('guest', ['except' => 'logout']);
+    }
+}

--- a/src/middleware/RedirectIfAuthenticated.php
+++ b/src/middleware/RedirectIfAuthenticated.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Nonoesp\Folio\Middleware;
+
+use Closure;
+use Illuminate\Support\Facades\Auth;
+
+class RedirectIfAuthenticated
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure  $next
+     * @param  string|null  $guard
+     * @return mixed
+     */
+    public function handle($request, Closure $next, $guard = null)
+    {
+        if (Auth::guard($guard)->check()) {
+            return redirect(route('admin.items'));
+        }
+
+        return $next($request);
+    }
+}

--- a/src/routes.php
+++ b/src/routes.php
@@ -9,7 +9,6 @@ use Redirect;
 use Config;
 use Request;
 use Markdown;
-use Authenticate; // nonoesp/authenticate
 use Recipient;
 use Property;
 use Input;
@@ -22,6 +21,18 @@ use \Illuminate\Support\Str;
 // ██╔══╝      ██║   ██║    ██║         ██║    ██║   ██║
 // ██║         ╚██████╔╝    ███████╗    ██║    ╚██████╔╝
 // ╚═╝          ╚═════╝     ╚══════╝    ╚═╝     ╚═════╝ 
+
+/*----------------------------------------------------------------*/
+/* LoginController
+/*----------------------------------------------------------------*/
+
+Route::group(['middleware' => 'web'], function () {
+
+	Route::view('login', 'folio::login.login')->middleware(\Nonoesp\Folio\Middleware\RedirectIfAuthenticated::class);
+	Route::post('login', 'Nonoesp\Folio\Controllers\LoginController@login')->name('login');
+	Route::post('logout', 'Nonoesp\Folio\Controllers\LoginController@logout')->name('logout');
+
+});
 
 /*----------------------------------------------------------------*/
 /* AdminController
@@ -38,7 +49,7 @@ Route::group([
 	Route::get($admin_path, 'Nonoesp\Folio\Controllers\AdminController@getDashboard');
 
 	// Items
-	Route::get($admin_path.'items', 'Nonoesp\Folio\Controllers\AdminController@getItemList');
+	Route::get($admin_path.'items', 'Nonoesp\Folio\Controllers\AdminController@getItemList')->name('admin.items');
 	Route::get($admin_path.'items/{tag}', 'Nonoesp\Folio\Controllers\AdminController@getItemList');
 	Route::any($admin_path.'item/edit/{id}', ['as' => 'item.edit', 'uses' => 'Nonoesp\Folio\Controllers\AdminController@ItemEdit']);
 	Route::any($admin_path.'item/versions/{id}', ['as' => 'item.version', 'uses' => 'Nonoesp\Folio\Controllers\AdminController@ItemVersions']);


### PR DESCRIPTION
This pull request removes the need to install `nonoesp/authenticate` as a separate package for authentication, making easier to maintain and fixing issues with middleware configuration that were preventing flash session data from working properly and fixing the "remember me" authentication feature.

- Simplifed `README.md` usage instructions.
- Added `RedirectIfAuthenticated` middleware.
- Removed calls to `Authenticate::isUserLoggedInTwitter()` method.
- Removed `nonoesp/authenticate` dependency from `composer.json`.
- Added `nonoesp/thinker` dependency.
- Changed default `middlewares-admin` from `['login', 'web']` to `['web', 'auth']` (where `auth` is an authentication middleware that ships with Laravel).
- Added `invalid-credentials` translations for failed login attempts.
- Added login `layout` and `login` views (previously on `nonoesp/authenticate`).
- Added `LoginController` (a controller that implements the `AuthenticatesUsers` trait and overrides certain methods, such as `$redirectTo`, `loggedOut`, `logout`, or `sendFailedLoginResponse`).
- Added `LoginController` routes (i.e. `login` view, and `login`, and `logout` post routes).
- Named `{admin}/items` as `admin.items`.